### PR TITLE
./gradlew assemble* 빌드 명령어 실패하는 문제 수정

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,5 +22,5 @@ android {
 dependencies {
     implementation 'com.facebook.react:react-native:+'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
-    implementation files('libs/ucrop-release.aar')
+    compileOnly files('libs/ucrop-release.aar')
 }


### PR DESCRIPTION
`./gradlew assembleRelease` 등, apk를 산출하는 빌드 명령시 다음과 같은 메시지로 실패하는 현상

```
* What went wrong:
Execution failed for task ':utae_react-native-image-crop-picker:bundleReleaseLocalLintAar'.
> Error while evaluating property 'hasLocalAarDeps' of task ':utae_react-native-image-crop-picker:bundleReleaseLocalLintAar'
   > Direct local .aar file dependencies are not supported when building an AAR. The resulting AAR would be broken because the classes and Android resources from any local .aar file dependencies would not be packaged in the resulting AAR. Previous versions of the Android Gradle Plugin produce broken AARs in this case too (despite not throwing this error). The following direct local .aar file dependencies of the :utae_react-native-image-crop-picker project caused this error: ********/node_modules/@utae/react-native-image-crop-picker/android/libs/ucrop-release.aar
```
(프로젝트 디렉토리 경로를 별표로 가렸습니다)

---

수정내용은
이리저리 구글링하다가..  동일 문제를 수정한 라이브러리 레포가 있길래 참고했고 ([이슈 코멘트](https://github.com/star-micronics/react-native-star-io10/issues/91#issuecomment-1551551719))
다행히 빌드는 잘 되더라구요 ㅎㅎ

어떤 이유로 이런 변경이 필요하게 된건지는 잘 모르겠어서.. 아쉽읍니다 😮‍💨 